### PR TITLE
마크다운 스타일 수정

### DIFF
--- a/src/components/PostDetail/PostBody/PostBody.style.ts
+++ b/src/components/PostDetail/PostBody/PostBody.style.ts
@@ -12,7 +12,7 @@ export const TableOfContent = styled.aside`
   position: absolute;
   height: 100%;
   right: 0px;
-  transform: translateX(-20%);
+  transform: translateX(-16%);
   padding: 1rem;
   font-size: 0.9rem;
 

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -120,6 +120,54 @@ const MarkdownStyle = css`
     tab-size: 2;
   }
 
+  table {
+    padding: 0;
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+  table tr {
+    border-top: 1px solid #d0d7de;
+    background-color: #ffffff; // dark: #0d1117
+    margin: 0;
+    padding: 0;
+  }
+  table tr:nth-child(2n) {
+    background-color: #f6f8fa; // dark: #161b22
+  }
+  thead {
+    display: table-header-group;
+    vertical-align: middle;
+    border-color: inherit;
+  }
+  tr {
+    display: table-row;
+    vertical-align: inherit;
+    border-color: inherit;
+  }
+  table tr th {
+    display: table-cell;
+    font-weight: bold;
+    border: 1px solid #d0d7de;
+    text-align: center;
+    margin: 0;
+    padding: 6px 13px;
+    vertical-align: inherit;
+  }
+  table tr td {
+    border: 1px solid #d0d7de;
+    text-align: left;
+    margin: 0;
+    padding: 6px 13px;
+  }
+  table tr th :first-child,
+  table tr td :first-child {
+    margin-top: 0;
+  }
+  table tr th :last-child,
+  table tr td :last-child {
+    margin-bottom: 0;
+  }
+
   // Markdown Responsive Design
   @media (max-width: 768px) {
     width: 100%;

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -105,14 +105,19 @@ const MarkdownStyle = css`
     }
   }
 
-  code[class*='language-'],
-  pre[class*='language-'] {
+  code[class*='language-text'],
+  pre[class*='language-text'] {
     padding: 1.6px 4.8px;
     font-size: 14.4px;
     background-color: rgb(215 218 221); // dark: rgb(73, 80, 87)
     font-weight: bold;
     color: rgb(33, 37, 41); //dark: rgb(248, 249, 250);
     font-size: 14.4px;
+  }
+
+  code[class*='language-'],
+  pre[class*='language-'] {
+    tab-size: 2;
   }
 
   // Markdown Responsive Design


### PR DESCRIPTION
# About

1. 코드 블록 세부 스타일
2. 테이블 스타일 적용

## Description

## 1. 코드 블록 세부 스타일

language-text와 나머지 (language-)를 구분해서 스타일 적용

language-text

![스크린샷 2023-01-25 오후 11 31 02](https://user-images.githubusercontent.com/71386219/214590235-77a4fda6-de23-4e91-af98-449d8b36746c.png)

(language-)

![스크린샷 2023-01-25 오후 11 30 52](https://user-images.githubusercontent.com/71386219/214590204-70197489-a391-486a-bee0-885f8be047a6.png)

## 2. 테이블 스타일 적용

깃허브 마크다운 css을 참고해서 적용

![스크린샷 2023-01-25 오후 11 30 33](https://user-images.githubusercontent.com/71386219/214590131-95605ab7-b892-4b59-b768-885029172d01.png)

