### PR TITLE
Bug/meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,22 @@
 
 ## 🐛 트러블 슈팅
 
+다크모드
+
 - [다크모드 구현 - css variable](https://github.com/kimyouknow/kimyouknow.github.io/pull/12)
 - [다크모드 에러 (dark mode flash error) 수정](https://github.com/kimyouknow/kimyouknow.github.io/pull/20)
+
+반응형 웹
+
 - [반응형 웹 - css variable](https://github.com/kimyouknow/kimyouknow.github.io/pull/18)
+
+SEO, 웹접근성
+
 - [SEO, 웹 접근성](https://github.com/kimyouknow/kimyouknow.github.io/pull/15)
+- [Slack에 메타 태그가 적용되지 않는 버그 수정](https://github.com/kimyouknow/kimyouknow.github.io/pull/27)
+
+기타
+
 - [github action을 활용한 gh-pages 배포 자동화](https://github.com/kimyouknow/kimyouknow.github.io/pull/9)
 - [이미지 처리](https://github.com/kimyouknow/kimyouknow.github.io/pull/9)
 

--- a/blog-config.js
+++ b/blog-config.js
@@ -3,7 +3,7 @@ require('dotenv').config({
 })
 
 module.exports = {
-  title: `Yunho.blog`,
+  siteName: `Yunho.blog`,
   author: 'Yunho(kimyouknow)',
   description: `안녕하세요. 프론트엔드 개발자 김윤호입니다. 고민과 문제 해결 과정을 공유하고 있습니다.`,
   siteUrl: 'https://kimyouknow.github.io/',

--- a/src/components/PostDetail/index.tsx
+++ b/src/components/PostDetail/index.tsx
@@ -1,5 +1,6 @@
 import PostFooter from '@/components/PostDetail/PostFooter'
 import SEO from '@/components/SEO'
+import useBlogConfig from '@/hooks/useBlogConfig'
 import Layout from '@/Layout'
 import { PostPageItemType } from '@/types/PostItem.types'
 
@@ -9,15 +10,10 @@ import PostHeader from './PostHeader'
 interface PostPageInfoProps {
   postPageInfo: PostPageItemType
   href: string
-  author: string
-  favicon: string
-  seo: {
-    google: string
-    naver: string
-  }
 }
 
-const PostDetail = ({ postPageInfo, href, author, favicon, seo }: PostPageInfoProps) => {
+const PostDetail = ({ postPageInfo, href }: PostPageInfoProps) => {
+  const { author, favicon, seo, siteName } = useBlogConfig()
   const {
     node: {
       tableOfContents,
@@ -40,12 +36,14 @@ const PostDetail = ({ postPageInfo, href, author, favicon, seo }: PostPageInfoPr
       <SEO
         author={author}
         siteUrl={href}
+        siteName={siteName}
         title={title}
         description={summary}
         image={publicURL}
         keywords={categories}
         favicon={favicon}
         seo={seo}
+        readingTime={readingTime.text}
       />
       <PostHeader
         title={title}

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -30,7 +30,7 @@ const SEO = ({
       <meta property="og:site_name" content={siteName} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={image} />
+      <meta property="og:image" content={`${siteUrl}${image}`} />
       <meta property="og:url" content={siteUrl} />
       <meta property="og:locale" content="ko_KR" />
       <meta property="og:locale:alternate" content="es_ES" />
@@ -39,7 +39,7 @@ const SEO = ({
       <meta name="twitter:domain" content={siteUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={image} />
+      <meta name="twitter:image" content={`${siteUrl}${image}`} />
       <meta name="twitter:image:alt" content={description} />
       <meta name="twitter:label1" content="Time to read" />
       <meta name="twitter:data1" content={readingTime} />

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -21,7 +21,6 @@ const SEO = ({
       <meta name="description" content={description} />
       <meta name="author" content={author} />
       <meta name="keywords" content={keywords.join(', ')} />
-      <link rel="icon" href={favicon} />
       <link rel="icon" type="image/png" href={favicon} sizes="16x16" />
       <meta name="google-site-verification" content={seo.google} />
       <meta name="naver-site-verification" content={seo.naver} />
@@ -33,9 +32,17 @@ const SEO = ({
       <meta property="og:description" content={description} />
       <meta property="og:image" content={image} />
       <meta property="og:url" content={siteUrl} />
-      <meta property="og:site_name" content={title} />
       <meta property="og:locale" content="ko_KR" />
       <meta property="og:locale:alternate" content="es_ES" />
+      {/* twitter cards tags additive with th og: tags  */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:domain" content={siteUrl} />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      <meta name="twitter:image:alt" content={description} />
+      <meta name="twitter:label1" content="Time to read" />
+      <meta name="twitter:data1" content={readingTime} />
     </Helmet>
   )
 }

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -2,7 +2,19 @@ import { Helmet } from 'react-helmet'
 
 import { SEOConfigType } from '@/types/gatsby.type'
 
-const SEO = ({ lang = 'ko', author, title, description, siteUrl, image, keywords, favicon, seo }: SEOConfigType) => {
+const SEO = ({
+  lang = 'ko',
+  author,
+  siteName,
+  siteUrl,
+  title = siteName,
+  description,
+  image,
+  keywords,
+  favicon,
+  seo,
+  readingTime,
+}: SEOConfigType) => {
   return (
     <Helmet htmlAttributes={{ lang }}>
       <title>{title}</title>
@@ -16,6 +28,7 @@ const SEO = ({ lang = 'ko', author, title, description, siteUrl, image, keywords
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       {/* property: og */}
       <meta property="og:type" content="website" />
+      <meta property="og:site_name" content={siteName} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={image} />

--- a/src/hooks/useBlogConfig.ts
+++ b/src/hooks/useBlogConfig.ts
@@ -15,7 +15,7 @@ const useBlogConfig = () => {
         site {
           siteMetadata {
             author
-            title
+            siteName
             description
             siteUrl
             image

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ const IndexPage = ({
     allMarkdownRemark: { edges },
   },
 }: IndexPageProps) => {
-  const { author, title, siteUrl, description, image, keywords, favicon, seo } = useBlogConfig()
+  const { author, siteName, siteUrl, description, image, keywords, favicon, seo } = useBlogConfig()
   const parsed: ParsedQuery<string> = queryString.parse(hash)
   const selectedCategory = typeof parsed.category !== 'string' || !parsed.category ? 'All' : parsed.category
   // category 프로퍼티 값이 문자열 형태가 아니거나 존재하지 않는 경우에는 기본적으로 카테고리 값을 All로 지정하고, 그러지 않은 경우에는 파싱한 값을 지정
@@ -60,7 +60,7 @@ const IndexPage = ({
       <SEO
         author={author}
         siteUrl={siteUrl}
-        title={title}
+        siteName={siteName}
         description={description}
         image={image}
         keywords={keywords}

--- a/src/templates/post.template.tsx
+++ b/src/templates/post.template.tsx
@@ -2,7 +2,6 @@ import { graphql } from 'gatsby'
 import React from 'react'
 
 import PostDetail from '@/components/PostDetail'
-import useBlogConfig from '@/hooks/useBlogConfig'
 import { PostPageItemType } from '@/types/PostItem.types'
 
 interface PostTemplateProps {
@@ -22,8 +21,7 @@ const PostTemplate = ({
   },
   location: { href },
 }: PostTemplateProps) => {
-  const { author, favicon, seo } = useBlogConfig()
-  return <PostDetail postPageInfo={edges[0]} href={href} author={author} favicon={favicon} seo={seo} />
+  return <PostDetail postPageInfo={edges[0]} href={href} />
 }
 
 export default PostTemplate

--- a/src/types/gatsby.type.ts
+++ b/src/types/gatsby.type.ts
@@ -11,8 +11,9 @@ export interface GatsbyImgProps {
 export interface SEOConfigType {
   lang?: string
   author: string
-  title: string
+  siteName: string
   siteUrl: string
+  title?: string
   description: string
   image: string
   keywords: string[]
@@ -21,6 +22,7 @@ export interface SEOConfigType {
     google: string
     naver: string
   }
+  readingTime?: string
 }
 
 export interface ConfigType extends SEOConfigType {


### PR DESCRIPTION
# About

slack에 메타 태그가 적용되지 않은 버그 수정

## Description

[slack공홈](https://slack.com/intl/ko-kr/help/articles/204399343-링크-공유-및-미리보기-환경설정-지정)에서 소개해준 페이지 ([Everything you ever wanted to know about unfurling but were afraid to ask /or/ How to make your site previews look amazing in Slack](https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254))를 토대로 설정

- twitter 관련 메타태그가 필요함.
- 상대경로가 아닌 절대 경로로 설정

![og](https://user-images.githubusercontent.com/71386219/218982063-dbc41f4c-1b49-4055-b4a7-a4d23fe8eb44.png)

> 출처: https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254

## Result



## Ref

#15 
#27 
- https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url 
